### PR TITLE
Allow Add Module button to wrap on narrow screens

### DIFF
--- a/src/components/ModuleList.tsx
+++ b/src/components/ModuleList.tsx
@@ -65,7 +65,7 @@ const ModuleList: React.FC = () => {
         <h2 className="text-2xl font-bold">Your Modules</h2>
         <form
           onSubmit={handleAdd}
-          className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center"
+          className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:flex-wrap sm:items-center"
         >
           <input
             value={name}
@@ -75,7 +75,7 @@ const ModuleList: React.FC = () => {
           />
           <button
             type="submit"
-            className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground dark:bg-slate-700 dark:text-white sm:w-auto"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground dark:bg-slate-700 dark:text-white sm:w-auto sm:flex-none"
           >
             <Plus size={16} /> Add
           </button>


### PR DESCRIPTION
## Summary
- allow the add-module form to wrap so the button can sit under the input when space is constrained
- prevent the add button from expanding horizontally in wrapped layouts

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_6903c4243df4833090cc7a9f44e4ae9a