### PR TITLE
Wrap module task controls on narrow screens

### DIFF
--- a/src/components/ModuleList.tsx
+++ b/src/components/ModuleList.tsx
@@ -65,7 +65,7 @@ const ModuleList: React.FC = () => {
         <h2 className="text-2xl font-bold">Your Modules</h2>
         <form
           onSubmit={handleAdd}
-          className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center"
+          className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:flex-wrap sm:items-center"
         >
           <input
             value={name}
@@ -75,7 +75,7 @@ const ModuleList: React.FC = () => {
           />
           <button
             type="submit"
-            className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground dark:bg-slate-700 dark:text-white sm:w-auto"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground dark:bg-slate-700 dark:text-white sm:w-auto sm:flex-none"
           >
             <Plus size={16} /> Add
           </button>

--- a/src/pages/Module.tsx
+++ b/src/pages/Module.tsx
@@ -357,9 +357,12 @@ const ModulePage: React.FC = () => {
                         // compute folder grade for display
                         const folderGrade = isFolder ? computeFolderGrade(t) : t.grade;
                         return (
-                          <div key={t.id} className={`py-2 flex items-start gap-3 ${t.excluded ? "opacity-50 grayscale" : ""}`}>
-                            <div className="flex-1">
-                              <div className="flex items-center justify-between">
+                          <div
+                            key={t.id}
+                            className={`py-2 flex flex-wrap items-start gap-3 md:flex-nowrap ${t.excluded ? "opacity-50 grayscale" : ""}`}
+                          >
+                            <div className="flex-1 min-w-0">
+                              <div className="flex flex-wrap items-center justify-between gap-2">
                                 <div>
                                   <div className="font-medium">{t.name}</div>
                                   <div className="text-sm text-muted-foreground mt-1">
@@ -433,7 +436,7 @@ const ModulePage: React.FC = () => {
                             </div>
 
                             {/* actions for top-level tasks and folders */}
-                            <div className="flex items-center gap-2">
+                            <div className="flex w-full flex-wrap items-center gap-2 md:w-auto md:flex-nowrap md:justify-end">
                               {!isFolder ? (
                                 <>
                                   {!isA2 ? (


### PR DESCRIPTION
## Summary
- allow module task rows to wrap so folder controls drop beneath their labels on small screens

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_6903c4243df4833090cc7a9f44e4ae9a