### PR TITLE
Use dedicated Kraken PWA icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Kraken" />
     <meta name="mobile-web-app-capable" content="yes" />
-    <link
-      rel="apple-touch-icon"
-      href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAIAAACyr5FlAAABSUlEQVR42u3SMQ0AAAgEsXfAiAf8C8QAK1uTKrhcqgdOkQBzYA7MgTkwB+bAHJgDc2AOMAfmwByYA3NgDsyBOTAH5gBzYA7MgTkwB+bAHJgDc2AOMAfmwByYA3NgDsyBOTAH5sAcYA7MgTkwB+bAHJgDc2AOzAHmwByYA3NgDsyBOTAH5sAcYA7MgTkwB+bAHJgDc2AOzIE5wByYA3NgDsyBOTAH5sAcmAPMgTkwB+bAHJgDc2AOzIE5wByYA3NgDsyBOTAH5sAcmANzgDkwB+bAHJgDc2AOzIE5MAeYA3NgDsyBOTAH5sAcmANzgDkwB+bAHJgDc2AOzIE5MAfmAHNgDsyBOTAH5sAcmANzYA4wB+bAHJgDc2AOzIE5MAfmAHNgDsyBOTAH5sAcmANzYA7MAebAHJgDc2AOzIE5MAfmwBxgDsyBOfiyieiPSrp5fm8AAAAASUVORK5CYII="
-    />
+    <link rel="apple-touch-icon" sizes="180x180" href="/icons/kraken-180.png" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="icon" href="/icon.svg" type="image/svg+xml" />
     <title>Kraken</title>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -10,6 +10,11 @@
   "theme_color": "#0f172a",
   "icons": [
     {
+      "src": "/icons/kraken-180.png",
+      "sizes": "180x180",
+      "type": "image/png"
+    },
+    {
       "src": "/icons/kraken-192.png",
       "sizes": "192x192",
       "type": "image/png"


### PR DESCRIPTION
## Summary
- point the Apple touch icon tag at the bundled 180px Kraken artwork
- register the new 180px icon in the web manifest alongside existing PWA icons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6904822ecccc8330b2752b10b45cb5c1