### PR TITLE
Fix error handling for Supabase sign-out

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,9 +15,14 @@ const Header: React.FC = () => {
   const navigate = useNavigate();
 
   const handleSignOut = async () => {
-    await signOut();
-    showSuccess("Signed out");
-    navigate("/");
+    try {
+      await signOut();
+      showSuccess("Signed out");
+      navigate("/");
+    } catch (error) {
+      console.error("Failed to sign out", error);
+      showError("Failed to sign out. Please try again.");
+    }
   };
 
   return (

--- a/src/contexts/SessionProvider.tsx
+++ b/src/contexts/SessionProvider.tsx
@@ -40,7 +40,12 @@ export const SessionProvider: React.FC<{ children: React.ReactNode }> = ({ child
   }, []);
 
   const signOut = async () => {
-    await supabase.auth.signOut();
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      throw error;
+    }
+    setSession(null);
+    setUser(null);
   };
 
   // Always render the context provider so the component tree and hook order remain stable.


### PR DESCRIPTION
## Summary
- add error handling around the Supabase sign-out call so users see a toast if it fails
- clear the cached session and user in the context after signing out to immediately update the header state

## Testing
- pnpm lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_690495c2db688330a12189e97a352d64