### PR TITLE
Redirect login success to home page

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -25,6 +25,18 @@ const Login: React.FC = () => {
   }, [navigate]);
 
   React.useEffect(() => {
+    const { data: authListener } = supabase.auth.onAuthStateChange((event, session) => {
+      if ((event === "SIGNED_IN" || event === "TOKEN_REFRESHED" || event === "USER_UPDATED") && session) {
+        navigate("/", { replace: true });
+      }
+    });
+
+    return () => {
+      authListener.subscription.unsubscribe();
+    };
+  }, [navigate]);
+
+  React.useEffect(() => {
     // Listen for changes to the root element's class list so we can toggle Auth theme/live text color.
     const root = typeof document !== "undefined" ? document.documentElement : null;
     if (!root) return;


### PR DESCRIPTION
## Summary
- add a Supabase auth state listener so successful sign-ins redirect to the home page

## Testing
- pnpm lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6904978f076083308cdc075d8ceeffbe